### PR TITLE
Integrate LatestDemoAPI address endpoints

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,6 @@
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <!-- index.html -->
-  <script src="https://cdn.tailwindcss.com"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
   </style>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,13 @@
         "@types/react": "^19.1.5",
         "@types/react-dom": "^19.1.5",
         "@vitejs/plugin-react": "^4.4.1",
+        "autoprefixer": "^10.4.21",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "globals": "^16.0.0",
+        "postcss": "^8.5.4",
+        "tailwindcss": "^4.1.8",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5"
@@ -1784,6 +1787,44 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/axios": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
@@ -2508,6 +2549,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2992,6 +3047,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3105,9 +3170,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
       "dev": true,
       "funding": [
         {
@@ -3125,13 +3190,20 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -3476,6 +3548,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
+      "integrity": "sha512-kjeW8gjdxasbmFKpVGrGd5T4i40mV5J2Rasw48QARfYeQ8YS9x02ON9SFWax3Qf616rt4Cp3nVNIj6Hd1mP3og==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "@types/react": "^19.1.5",
     "@types/react-dom": "^19.1.5",
     "@vitejs/plugin-react": "^4.4.1",
+    "autoprefixer": "^10.4.21",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "postcss": "^8.5.4",
+    "tailwindcss": "^4.1.8",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
 import { AddressList } from './components/pages/AddressList';
-// import CreateAddress from './pages/CreateAddress';
+import { AddressForm } from './components/pages/AddressForm';
 
 function App() {
   return (
@@ -9,8 +9,8 @@ function App() {
       <Routes>
         <Route path="/" element={<AppLayout />}>
           <Route index element={<AddressList />} />
-          {/* <Route path="create" element={<CreateAddress />} /> */}
-          {/* Add more routes here */}
+          <Route path="create" element={<AddressForm />} />
+          <Route path="edit/:id" element={<AddressForm />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,26 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { AppLayout } from './components/layout/AppLayout';
+import { RequireAuth } from './components/layout/RequireAuth';
 import { AddressList } from './components/pages/AddressList';
 import { AddressForm } from './components/pages/AddressForm';
+import { LoginPage } from './components/pages/LoginPage';
+import { RegisterPage } from './components/pages/RegisterPage';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<AppLayout />}>
-          <Route index element={<AddressList />} />
-          <Route path="create" element={<AddressForm />} />
-          <Route path="edit/:id" element={<AddressForm />} />
+          <Route index element={<Navigate to="login" replace />} />
+          <Route path="login" element={<LoginPage />} />
+          <Route path="register" element={<RegisterPage />} />
+          <Route element={<RequireAuth />}>
+            <Route path="addresses" element={<AddressList />} />
+            <Route path="addresses/create" element={<AddressForm />} />
+            <Route path="addresses/edit/:id" element={<AddressForm />} />
+          </Route>
         </Route>
+        <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/api/addressService.ts
+++ b/src/api/addressService.ts
@@ -1,0 +1,43 @@
+import apiClient from './apiClient';
+import type { Address } from '../models/Address';
+import type { PaginatedResponse } from '../models/PaginatedResponse';
+
+export interface AddressInput {
+    country: string;
+    state: string;
+    city: string;
+    pinCode: string;
+    landMark?: string;
+}
+
+const endpoint = 'Address';
+
+export const addressService = {
+    getAll: async (
+        pageNumber = 1,
+        pageSize = 5,
+        filters?: { city?: string; state?: string }
+    ): Promise<PaginatedResponse<Address>> => {
+        const params = { pageNumber, pageSize, ...filters };
+        const response = await apiClient.get<PaginatedResponse<Address>>(`/${endpoint}`, { params });
+        return response.data;
+    },
+
+    getById: async (id: string): Promise<Address> => {
+        const response = await apiClient.get<Address>(`/${endpoint}/${id}`);
+        return response.data;
+    },
+
+    create: async (data: AddressInput): Promise<Address> => {
+        const response = await apiClient.post<Address>(`/${endpoint}`, data);
+        return response.data;
+    },
+
+    update: async (id: string, data: AddressInput): Promise<void> => {
+        await apiClient.put(`/${endpoint}/${id}`, data);
+    },
+
+    remove: async (id: string): Promise<void> => {
+        await apiClient.delete(`/${endpoint}/${id}`);
+    },
+};

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -7,4 +7,13 @@ const apiClient = axios.create({
     },
 });
 
+apiClient.interceptors.request.use((config) => {
+    const token = localStorage.getItem('token');
+    if (token) {
+        config.headers = config.headers ?? {};
+        (config.headers as Record<string, string>).Authorization = `Bearer ${token}`;
+    }
+    return config;
+});
+
 export default apiClient;

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import type { InternalAxiosRequestConfig } from 'axios'; // Import correct type for config
 
 const apiClient = axios.create({
     baseURL: 'https://localhost:7096/api/',
@@ -7,24 +8,12 @@ const apiClient = axios.create({
     },
 });
 
-apiClient.interceptors.request.use((config) => {
+apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
     const token = localStorage.getItem('token');
     if (token) {
-        config.headers = config.headers ?? {};
-        (config.headers as Record<string, string>).Authorization = `Bearer ${token}`;
+        config.headers.set('Authorization', `Bearer ${token}`); // ✅ Use `set()` method on headers
     }
     return config;
 });
-
-apiClient.interceptors.response.use(
-    response => response,
-    error => {
-        if (error.response && error.response.status === 401) {
-            localStorage.removeItem('token');
-            window.location.href = '/login';
-        }
-        return Promise.reject(error);
-    }
-);
 
 export default apiClient;

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,24 +1,27 @@
-import axios from 'axios';
-const existingToken = localStorage.getItem('token');
-if (existingToken) {
-    apiClient.defaults.headers.common['Authorization'] = `Bearer ${existingToken}`;
-}
-
-import type { InternalAxiosRequestConfig } from 'axios'; // Import correct type for config
-
-const apiClient = axios.create({
-    baseURL: 'https://localhost:7096/api/',
-    headers: {
-        'Content-Type': 'application/json',
-    },
-});
-
-apiClient.interceptors.request.use((config: InternalAxiosRequestConfig) => {
-    const token = localStorage.getItem('token');
-    if (token) {
-        config.headers.set('Authorization', `Bearer ${token}`); // ✅ Use `set()` method on headers
-    }
-    return config;
-});
-
-export default apiClient;
+import axios from 'axios'
+  baseURL: 'https://localhost:7096/api/',
+  headers: {
+    'Content-Type': 'application/json',
+  },
+})
+export const initializeClient = (): void => {
+  const existingToken = localStorage.getItem('token')
+  if (existingToken) {
+    apiClient.defaults.headers.common['Authorization'] = `Bearer ${existingToken}`
+  }
+  const token = localStorage.getItem('token')
+  if (token) {
+    config.headers = config.headers ?? {}
+    ;(config.headers as Record<string, string>).Authorization = `Bearer ${token}`
+  }
+  return config
+})
+  response => response,
+  error => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem('token')
+      delete apiClient.defaults.headers.common['Authorization']
+      window.location.href = '/login'
+    return Promise.reject(error)
+  },
+)

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -16,4 +16,15 @@ apiClient.interceptors.request.use((config) => {
     return config;
 });
 
+apiClient.interceptors.response.use(
+    response => response,
+    error => {
+        if (error.response && error.response.status === 401) {
+            localStorage.removeItem('token');
+            window.location.href = '/login';
+        }
+        return Promise.reject(error);
+    }
+);
+
 export default apiClient;

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,9 @@
 import axios from 'axios';
+const existingToken = localStorage.getItem('token');
+if (existingToken) {
+    apiClient.defaults.headers.common['Authorization'] = `Bearer ${existingToken}`;
+}
+
 import type { InternalAxiosRequestConfig } from 'axios'; // Import correct type for config
 
 const apiClient = axios.create({

--- a/src/api/authService.ts
+++ b/src/api/authService.ts
@@ -1,0 +1,23 @@
+import apiClient from './apiClient';
+
+export interface LoginInput {
+    username: string;
+    password: string;
+}
+
+export interface RegisterInput {
+    username: string;
+    password: string;
+}
+
+const authService = {
+    login: async (data: LoginInput): Promise<string> => {
+        const res = await apiClient.post<{ token: string }>('/auth/login', data);
+        return res.data.token;
+    },
+    register: async (data: RegisterInput): Promise<void> => {
+        await apiClient.post('/auth/register', data);
+    }
+};
+
+export default authService;

--- a/src/api/authService.ts
+++ b/src/api/authService.ts
@@ -12,7 +12,7 @@ export interface RegisterInput {
 
 const authService = {
     login: async (data: LoginInput): Promise<string> => {
-        const res = await apiClient.post<{ token: string }>('/auth/login', data);
+        const res = await apiClient.post<{ token: string }>('/auth/token', data);
         return res.data.token;
     },
     register: async (data: RegisterInput): Promise<void> => {

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,70 +1,22 @@
-import { useState, type FC } from 'react';
-import { AppButton } from '../ui/AppButton';
+import React from 'react';
+import { Link } from 'react-router-dom';
 
-export const AppHeader: FC = () => {
-    const [menuOpen, setMenuOpen] = useState(false);
-    const links = ['Home', 'Features', 'Pricing', 'FAQs', 'About'];
-
+export const AppHeader: React.FC = () => {
+    const token = localStorage.getItem('token');
     return (
-        <header className="fixed top-0 w-full z-50 bg-[#1F1F1F] shadow-md">
-            <nav className="flex items-center justify-between px-4 py-3 max-w-screen-xl mx-auto relative">
-                {/* Left: Logo and Navigation */}
-                <div className="flex items-center space-x-6">
-                    <div className="flex items-center justify-center w-8 h-8 rounded-md bg-[#2B2E33] text-white font-bold text-lg font-sans select-none">
-                        B
-                    </div>
-                    <div className="hidden md:flex items-center space-x-6">
-                        {links.map((label, idx) => (
-                            <a
-                                key={idx}
-                                href="#"
-                                className={`text-sm font-normal transition ${label === 'Features' ? 'text-white hover:underline' : 'text-gray-400 hover:text-white'}`}
-                            >
-                                {label}
-                            </a>
-                        ))}
-                    </div>
+        <header className="bg-gray-800 text-white">
+            <nav className="max-w-4xl mx-auto px-4 py-3 flex justify-between items-center">
+                <Link to="/" className="text-lg font-semibold">LatestDemo</Link>
+                <div className="space-x-4">
+                    {token ? (
+                        <Link to="/">Addresses</Link>
+                    ) : (
+                        <>
+                            <Link to="/login" className="hover:underline">Login</Link>
+                            <Link to="/register" className="hover:underline">Register</Link>
+                        </>
+                    )}
                 </div>
-
-                {/* Right: Search Input + Buttons */}
-                <div className="flex items-center space-x-3">
-                    <input
-                        type="text"
-                        placeholder="Search..."
-                        className="bg-[#2B2E33] text-gray-400 text-sm rounded px-3 py-1 w-28 md:w-36 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
-                    />
-
-                    <AppButton
-                        label="Login"
-                        className="p-button-outlined p-button-sm border border-gray-500 text-white hover:bg-gray-700 transition"
-                    />
-
-                    <AppButton
-                        label="Sign-up"
-                        className="p-button-sm bg-yellow-500 text-black hover:bg-yellow-600 transition"
-                    />
-
-                    <button className="md:hidden text-gray-400" onClick={() => setMenuOpen(prev => !prev)}>
-                        <i className="pi pi-bars text-xl" />
-                    </button>
-                </div>
-
-                {menuOpen && (
-                    <div className="absolute top-full left-0 w-full bg-[#1F1F1F] md:hidden shadow-md">
-                        <div className="flex flex-col space-y-2 px-4 py-3">
-                            {links.map((label, idx) => (
-                                <a
-                                    key={idx}
-                                    href="#"
-                                    className="text-gray-300 text-sm hover:text-white"
-                                    onClick={() => setMenuOpen(false)}
-                                >
-                                    {label}
-                                </a>
-                            ))}
-                        </div>
-                    </div>
-                )}
             </nav>
         </header>
     );

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+import apiClient from '../../api/apiClient';
 
 export const AppHeader: React.FC = () => {
     const [menuOpen, setMenuOpen] = useState(false);
@@ -8,6 +9,7 @@ export const AppHeader: React.FC = () => {
 
     const handleLogout = () => {
         localStorage.removeItem('token');
+        delete apiClient.defaults.headers.common['Authorization'];
         navigate('/login');
     };
 

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,34 +1,37 @@
-import type { FC } from "react";
-import { AppButton } from "../ui/AppButton";
+import { useState, type FC } from 'react';
+import { AppButton } from '../ui/AppButton';
 
 export const AppHeader: FC = () => {
+    const [menuOpen, setMenuOpen] = useState(false);
+    const links = ['Home', 'Features', 'Pricing', 'FAQs', 'About'];
+
     return (
         <header className="fixed top-0 w-full z-50 bg-[#1F1F1F] shadow-md">
-            <nav className="flex items-center justify-between px-4 py-3 max-w-screen-xl mx-auto">
-                {/* Left: Logo and Navigation Links */}
+            <nav className="flex items-center justify-between px-4 py-3 max-w-screen-xl mx-auto relative">
+                {/* Left: Logo and Navigation */}
                 <div className="flex items-center space-x-6">
                     <div className="flex items-center justify-center w-8 h-8 rounded-md bg-[#2B2E33] text-white font-bold text-lg font-sans select-none">
                         B
                     </div>
-
-                    {["Home", "Features", "Pricing", "FAQs", "About"].map((label, idx) => (
-                        <a
-                            key={idx}
-                            href="#"
-                            className={`text-sm font-normal transition ${label === "Features" ? "text-white hover:underline" : "text-gray-400 hover:text-white"
-                                }`}
-                        >
-                            {label}
-                        </a>
-                    ))}
+                    <div className="hidden md:flex items-center space-x-6">
+                        {links.map((label, idx) => (
+                            <a
+                                key={idx}
+                                href="#"
+                                className={`text-sm font-normal transition ${label === 'Features' ? 'text-white hover:underline' : 'text-gray-400 hover:text-white'}`}
+                            >
+                                {label}
+                            </a>
+                        ))}
+                    </div>
                 </div>
 
-                {/* Right: Search Input + AppButtons */}
+                {/* Right: Search Input + Buttons */}
                 <div className="flex items-center space-x-3">
                     <input
                         type="text"
                         placeholder="Search..."
-                        className="bg-[#2B2E33] text-gray-400 text-sm rounded px-3 py-1 w-36 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
+                        className="bg-[#2B2E33] text-gray-400 text-sm rounded px-3 py-1 w-28 md:w-36 placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
                     />
 
                     <AppButton
@@ -40,7 +43,28 @@ export const AppHeader: FC = () => {
                         label="Sign-up"
                         className="p-button-sm bg-yellow-500 text-black hover:bg-yellow-600 transition"
                     />
+
+                    <button className="md:hidden text-gray-400" onClick={() => setMenuOpen(prev => !prev)}>
+                        <i className="pi pi-bars text-xl" />
+                    </button>
                 </div>
+
+                {menuOpen && (
+                    <div className="absolute top-full left-0 w-full bg-[#1F1F1F] md:hidden shadow-md">
+                        <div className="flex flex-col space-y-2 px-4 py-3">
+                            {links.map((label, idx) => (
+                                <a
+                                    key={idx}
+                                    href="#"
+                                    className="text-gray-300 text-sm hover:text-white"
+                                    onClick={() => setMenuOpen(false)}
+                                >
+                                    {label}
+                                </a>
+                            ))}
+                        </div>
+                    </div>
+                )}
             </nav>
         </header>
     );

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,19 +1,33 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 
 export const AppHeader: React.FC = () => {
+    const [menuOpen, setMenuOpen] = useState(false);
+    const navigate = useNavigate();
     const token = localStorage.getItem('token');
+
+    const handleLogout = () => {
+        localStorage.removeItem('token');
+        navigate('/login');
+    };
+
     return (
-        <header className="bg-gray-800 text-white">
-            <nav className="max-w-4xl mx-auto px-4 py-3 flex justify-between items-center">
-                <Link to="/" className="text-lg font-semibold">LatestDemo</Link>
-                <div className="space-x-4">
+        <header className="bg-gray-800 text-white fixed top-0 left-0 right-0 z-10">
+            <nav className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+                <Link to="/" className="text-lg font-semibold" onClick={() => setMenuOpen(false)}>LatestDemo</Link>
+                <button className="md:hidden" onClick={() => setMenuOpen(o => !o)}>
+                    <i className="pi pi-bars" />
+                </button>
+                <div className={`${menuOpen ? 'block' : 'hidden'} md:flex md:items-center space-x-4`}> 
                     {token ? (
-                        <Link to="/">Addresses</Link>
+                        <>
+                            <Link to="/addresses" className="block" onClick={() => setMenuOpen(false)}>Addresses</Link>
+                            <button onClick={() => { setMenuOpen(false); handleLogout(); }} className="block">Logout</button>
+                        </>
                     ) : (
                         <>
-                            <Link to="/login" className="hover:underline">Login</Link>
-                            <Link to="/register" className="hover:underline">Register</Link>
+                            <Link to="/login" onClick={() => setMenuOpen(false)} className="block hover:underline">Login</Link>
+                            <Link to="/register" onClick={() => setMenuOpen(false)} className="block hover:underline">Register</Link>
                         </>
                     )}
                 </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -5,7 +5,7 @@ export const AppLayout = () => {
     return (
         <div className="min-h-screen flex flex-col bg-gray-100">
             <AppHeader />
-            <main className="flex-grow p-4">
+            <main className="flex-grow p-4 pt-16">
                 <Outlet />
             </main>
         </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -5,7 +5,7 @@ export const AppLayout = () => {
     return (
         <div className="min-h-screen flex flex-col bg-gray-100">
             <AppHeader />
-            <main className="flex-grow pt-16 p-4">
+            <main className="flex-grow p-4">
                 <Outlet />
             </main>
         </div>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -3,9 +3,9 @@ import { AppHeader } from './AppHeader';
 
 export const AppLayout = () => {
     return (
-        <div>
+        <div className="min-h-screen flex flex-col bg-gray-100">
             <AppHeader />
-            <main className="p-4">
+            <main className="flex-grow pt-16 p-4">
                 <Outlet />
             </main>
         </div>

--- a/src/components/layout/RequireAuth.tsx
+++ b/src/components/layout/RequireAuth.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+
+export const RequireAuth: React.FC = () => {
+    const token = localStorage.getItem('token');
+    return token ? <Outlet /> : <Navigate to="/login" replace />;
+};

--- a/src/components/pages/AddressForm.tsx
+++ b/src/components/pages/AddressForm.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import type { Address } from '../../models/Address';
+import { AppForm, type FormField } from '../ui/AppForm';
+import { addressService, type AddressInput } from '../../api/addressService';
+
+export const AddressForm = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const isEdit = Boolean(id);
+
+    const [model, setModel] = useState<AddressInput>({
+        country: '',
+        state: '',
+        city: '',
+        pinCode: '',
+        landMark: '',
+    });
+
+    useEffect(() => {
+        if (isEdit && id) {
+            addressService.getById(id).then((data: Address) => {
+                setModel({
+                    country: data.country,
+                    state: data.state,
+                    city: data.city,
+                    pinCode: data.pinCode,
+                    landMark: data.landMark ?? '',
+                });
+            });
+        }
+    }, [id, isEdit]);
+
+    const fields: FormField<AddressInput>[] = [
+        { key: 'country', label: 'Country', required: true },
+        { key: 'state', label: 'State', required: true },
+        { key: 'city', label: 'City', required: true },
+        { key: 'pinCode', label: 'Pin Code', required: true },
+        { key: 'landMark', label: 'Landmark' },
+    ];
+
+    const handleChange = (key: keyof AddressInput, value: string | null) => {
+        setModel(prev => ({ ...prev, [key]: value ?? '' }));
+    };
+
+    const handleSubmit = async () => {
+        try {
+            if (isEdit && id) {
+                await addressService.update(id, model);
+            } else {
+                await addressService.create(model);
+            }
+            navigate('/');
+        } catch (err) {
+            console.error('Failed to save address', err);
+        }
+    };
+
+    return (
+        <div className="max-w-md mx-auto pt-20">
+            <AppForm model={model} fields={fields} onChange={handleChange} onSubmit={handleSubmit} />
+        </div>
+    );
+};

--- a/src/components/pages/AddressForm.tsx
+++ b/src/components/pages/AddressForm.tsx
@@ -57,7 +57,7 @@ export const AddressForm = () => {
     };
 
     return (
-        <div className="max-w-md mx-auto pt-20">
+        <div className="max-w-md mx-auto bg-white shadow rounded-md p-4 mt-8">
             <AppForm model={model} fields={fields} onChange={handleChange} onSubmit={handleSubmit} />
         </div>
     );

--- a/src/components/pages/AddressList.tsx
+++ b/src/components/pages/AddressList.tsx
@@ -39,8 +39,8 @@ export const AddressList: React.FC = () => {
     };
 
     return (
-        <div className="min-h-screen bg-gray-100 pt-20 overflow-hidden">
-            <div className="max-w-4xl mx-auto px-4 space-y-3">
+        <div className="pt-8 pb-10 overflow-hidden">
+            <div className="max-w-4xl mx-auto px-4 space-y-4 bg-white shadow rounded-md p-4">
                 <div className="flex justify-end">
                     <AppButton label="Create" onClick={() => navigate('create')} />
                 </div>

--- a/src/components/pages/AddressList.tsx
+++ b/src/components/pages/AddressList.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { AppTable } from '../ui/AppTable';
+import { AppButton } from '../ui/AppButton';
 import type { Address } from '../../models/Address';
-import type { PaginatedResponse } from '../../models/PaginatedResponse';
-import { createApiService } from '../../api/apiService';
+import { addressService } from '../../api/addressService';
 
 const columns: { field: keyof Address; header: string }[] = [
     { field: 'country', header: 'Country' },
@@ -16,13 +17,11 @@ export const AddressList: React.FC = () => {
     const [pageNumber, setPageNumber] = useState(0);
     const [pageSize, setPageSize] = useState(5);
     const [totalCount, setTotalCount] = useState(0);
+    const navigate = useNavigate();
 
     const fetchAddresses = async (page: number, size: number) => {
         try {
-            const api = createApiService<PaginatedResponse<Address>>(
-                `Address?pageNumber=${page + 1}&pageSize=${size}`
-            );
-            const res = await api.getAll();
+            const res = await addressService.getAll(page + 1, size);
             setAddresses(res.items);
             setTotalCount(res.totalCount);
         } catch (error) {
@@ -41,7 +40,10 @@ export const AddressList: React.FC = () => {
 
     return (
         <div className="min-h-screen bg-gray-100 pt-20 overflow-hidden">
-            <div className="max-w-4xl mx-auto px-4">
+            <div className="max-w-4xl mx-auto px-4 space-y-3">
+                <div className="flex justify-end">
+                    <AppButton label="Create" onClick={() => navigate('create')} />
+                </div>
                 <AppTable
                     data={addresses}
                     totalRecords={totalCount}
@@ -49,8 +51,13 @@ export const AddressList: React.FC = () => {
                     rowsPerPage={pageSize}
                     onPaginationChange={handlePaginationChange}
                     columns={columns}
-                    onEdit={(item) => console.log('Edit', item)}
-                    onDelete={(item) => console.log('Delete', item)}
+                    onEdit={(item) => navigate(`edit/${item.id}`)}
+                    onDelete={async (item) => {
+                        if (item.id) {
+                            await addressService.remove(item.id);
+                            fetchAddresses(pageNumber, pageSize);
+                        }
+                    }}
                 />
             </div>
         </div>

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { AppInputText } from '../ui/AppInputText';
 import { AppButton } from '../ui/AppButton';
 import authService from '../../api/authService';
+import apiClient from '../../api/apiClient';
 
 export const LoginPage: React.FC = () => {
     const navigate = useNavigate();
@@ -15,6 +16,7 @@ export const LoginPage: React.FC = () => {
         try {
             const token = await authService.login({ username, password });
             localStorage.setItem('token', token);
+            apiClient.defaults.headers.common['Authorization'] = `Bearer ${token}`;
             navigate('/addresses');
         } catch {
             setError('Invalid credentials');

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AppInputText } from '../ui/AppInputText';
+import { AppButton } from '../ui/AppButton';
+import authService from '../../api/authService';
+
+export const LoginPage: React.FC = () => {
+    const navigate = useNavigate();
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        try {
+            const token = await authService.login({ username, password });
+            localStorage.setItem('token', token);
+            navigate('/');
+        } catch {
+            setError('Invalid credentials');
+        }
+    };
+
+    return (
+        <div className="flex justify-center items-center h-screen bg-gray-100">
+            <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-3">
+                <h2 className="text-xl font-semibold text-center">Login</h2>
+                {error && <div className="text-red-500 text-sm">{error}</div>}
+                <AppInputText id="username" label="Username" value={username} onChange={setUsername} required />
+                <AppInputText id="password" label="Password" type="password" value={password} onChange={setPassword} required />
+                <AppButton label="Login" type="submit" className="w-full" />
+            </form>
+        </div>
+    );
+};

--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -15,7 +15,7 @@ export const LoginPage: React.FC = () => {
         try {
             const token = await authService.login({ username, password });
             localStorage.setItem('token', token);
-            navigate('/');
+            navigate('/addresses');
         } catch {
             setError('Invalid credentials');
         }

--- a/src/components/pages/RegisterPage.tsx
+++ b/src/components/pages/RegisterPage.tsx
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AppInputText } from '../ui/AppInputText';
+import { AppButton } from '../ui/AppButton';
+import authService from '../../api/authService';
+
+export const RegisterPage: React.FC = () => {
+    const navigate = useNavigate();
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        try {
+            await authService.register({ username, password });
+            navigate('/login');
+        } catch {
+            setError('Failed to register');
+        }
+    };
+
+    return (
+        <div className="flex justify-center items-center h-screen bg-gray-100">
+            <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-full max-w-sm space-y-3">
+                <h2 className="text-xl font-semibold text-center">Register</h2>
+                {error && <div className="text-red-500 text-sm">{error}</div>}
+                <AppInputText id="username" label="Username" value={username} onChange={setUsername} required />
+                <AppInputText id="password" label="Password" type="password" value={password} onChange={setPassword} required />
+                <AppButton label="Register" type="submit" className="w-full" />
+            </form>
+        </div>
+    );
+};

--- a/src/components/ui/AppDropdown.tsx
+++ b/src/components/ui/AppDropdown.tsx
@@ -1,31 +1,33 @@
 import { Dropdown } from 'primereact/dropdown';
 import React from 'react';
 
-interface AppDropdownProps {
+interface AppDropdownProps<T> {
     id: string;
     label: string;
-    value: any;
-    options: { label: string; value: any }[];
-    onChange: (value: any) => void;
+    value: T;
+    options: { label: string; value: T }[];
+    onChange: (value: T) => void;
     required?: boolean;
 }
 
-export const AppDropdown: React.FC<AppDropdownProps> = ({
+export function AppDropdown<T>({
     id,
     label,
     value,
     options,
     onChange,
     required
-}) => (
-    <div className="p-field">
-        <label htmlFor={id}>{label}{required ? ' *' : ''}</label>
-        <Dropdown
-            id={id}
-            value={value}
-            options={options}
-            onChange={e => onChange(e.value)}
-            className="w-full"
-        />
-    </div>
-);
+}: AppDropdownProps<T>) {
+    return (
+        <div className="p-field">
+            <label htmlFor={id}>{label}{required ? ' *' : ''}</label>
+            <Dropdown
+                id={id}
+                value={value}
+                options={options}
+                onChange={(e) => onChange(e.value as T)}
+                className="w-full"
+            />
+        </div>
+    );
+}

--- a/src/components/ui/AppForm.tsx
+++ b/src/components/ui/AppForm.tsx
@@ -11,14 +11,14 @@ export type FormField<T> = {
     label: string;
     type?: FieldType;
     required?: boolean;
-    options?: { label: string; value: any }[];
+    options?: { label: string; value: unknown }[];
 };
 
 export interface AppFormProps<T> {
     model: T;
     fields: FormField<T>[];
     onSubmit: (model: T) => void;
-    onChange: (key: keyof T, value: any) => void;
+    onChange: (key: keyof T, value: unknown) => void;
 }
 
 export function AppForm<T>({

--- a/src/components/ui/AppInputText.tsx
+++ b/src/components/ui/AppInputText.tsx
@@ -7,11 +7,12 @@ interface AppInputTextProps {
     value: string;
     onChange: (val: string) => void;
     required?: boolean;
+    type?: string;
 }
 
-export const AppInputText: React.FC<AppInputTextProps> = ({ id, label, value, onChange, required }) => (
+export const AppInputText: React.FC<AppInputTextProps> = ({ id, label, value, onChange, required, type = 'text' }) => (
     <div className="p-field">
         <label htmlFor={id}>{label}{required ? ' *' : ''}</label>
-        <InputText id={id} value={value} onChange={e => onChange(e.target.value)} className="w-full" />
+        <InputText id={id} type={type} value={value} onChange={e => onChange(e.target.value)} className="w-full" />
     </div>
 );

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 .layout-wrapper {
   display: flex;
   flex-direction: column;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import 'primereact/resources/themes/lara-light-blue/theme.css';
-import 'primereact/resources/primereact.min.css';
-import 'primeicons/primeicons.css';
+import 'primereact/resources/themes/lara-light-blue/theme.css'
+import 'primereact/resources/primereact.min.css'
+import 'primeicons/primeicons.css'
+import { initializeClient } from './api/apiClient'
+
+initializeClient()
 
 
 createRoot(document.getElementById('root')!).render(
@@ -12,3 +15,4 @@ createRoot(document.getElementById('root')!).render(
     <App />
   </StrictMode>,
 )
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}
+


### PR DESCRIPTION
## Summary
- add `addressService` for communication with LatestDemoAPI
- add dynamic `AddressForm` for creating and updating addresses
- enhance `AddressList` with create/edit/delete support
- update dropdown and form utilities to use generics
- register new routes for address form

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684284afbc988329a0039f0632e473a8